### PR TITLE
refactor(brand): softer drop-shadow glow on horizontal logo

### DIFF
--- a/.github/assets/logo-horizontal.svg
+++ b/.github/assets/logo-horizontal.svg
@@ -1,15 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 200" fill="none">
   <defs>
     <filter id="glow" x="-10%" y="-50%" width="120%" height="200%">
-      <feMorphology in="SourceAlpha" operator="dilate" radius="2.5"/>
-      <feGaussianBlur stdDeviation="4"/>
-      <feComponentTransfer><feFuncA type="linear" slope="2.4"/></feComponentTransfer>
-      <feColorMatrix type="matrix" values="0 0 0 0 1  0 0 0 0 1  0 0 0 0 1  0 0 0 1 0"/>
-      <feComposite in2="SourceGraphic" operator="out" result="glow"/>
-      <feMerge>
-        <feMergeNode in="glow"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
+      <feDropShadow dx="0" dy="0" stdDeviation="6" flood-color="#ffffff" flood-opacity="0.9"/>
+      <feDropShadow dx="0" dy="0" stdDeviation="2" flood-color="#ffffff" flood-opacity="0.9"/>
     </filter>
   </defs>
   <title>movie-info</title>


### PR DESCRIPTION
Follow-up to the previous halo PR. Replaces the hard-edged `feMorphology` + `feGaussianBlur` filter with two stacked `<feDropShadow>` primitives — the SVG equivalent of `filter: drop-shadow(0 0 6px #fff) drop-shadow(0 0 2px #fff)`. Result: invisible on light backgrounds, soft white shadow on GitHub's dark mode.