### PR TITLE
chore: fix package.json repository field

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "3.0.3",
   "description": "Get information, images, rating, description, etc. about a movie.",
   "license": "MIT",
-  "repository": "lacymorrow/movie-info",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lacymorrow/movie-info.git"
+  },
   "main": "index.js",
   "browser": "index.js",
   "author": {


### PR DESCRIPTION
## Summary
- Normalize `repository` field in package.json per npm publish standards
- Convert string shorthand to object format with `type` and `url`
- Normalize URLs to `git+https://` format

Automated fix via `npm pkg fix`. Addresses npm publish warnings.